### PR TITLE
Add message when authenticated, but account doesn't exist

### DIFF
--- a/controller/site/impl.go
+++ b/controller/site/impl.go
@@ -320,10 +320,20 @@ func (controller *SiteController) Logout(ctx *context.Context) error {
 }
 
 func (controller *SiteController) Join(ctx *context.Context) error {
+	accountExists := false
+	if ctx.LoggedIn {
+		_, err := controller.svc.User.GetUser(ctx.Username)
+		if err == nil {
+			accountExists = true
+		}
+	}
+
 	params := struct {
 		Authenticated bool
+		AccountExists bool
 	}{
 		Authenticated: ctx.LoggedIn,
+		AccountExists: accountExists,
 	}
 
 	return ctx.Render(http.StatusOK, "join", params)

--- a/template/join.html
+++ b/template/join.html
@@ -5,6 +5,11 @@
     <header>
         <h1>Joining ACM@UIUC</h1>
     </header>
+    {{if and .Authenticated (not .AccountExists)}}
+        <h5><b>You are logged in but do not have an ACM@UIUC account.</b></h5>
+        <p><b>Students / Faculty: Please fill out the joining form below.</b></p>
+        <p><b>Recruiters: Please reach out to <a href="mailto:corporate@acm.illinois.edu">corporate@acm.illinois.edu</a> for help setting up your account.</b></p>
+    {{end}}
     <p>
     Joining ACM is completely free! Once you've found your niche in ACM or one of its SIGs, becoming an official member is easy. 
     To become an official member, you need to fill out the quick and easy form below. If you would like to support ACM’s operations, you can 


### PR DESCRIPTION
We already have logic in place to redirect authenticated user that do not have an account to the `/join` page. This PR adds a message to that page explaining what the user should do. This message is primarily targeted at recruiters which might login to the page before their account is created and be confused by the join form (which is only for UIUC members).