### PR TITLE
Update gitstore base uri

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@ var defaultConfig = map[string]string{
 	"DB_PASS":                     "devpass",
 	"DB_HOST":                     "(localhost:3306)",
 	"DB_NAME":                     "core",
-	"GITSTORE_BASE_URI":           "https://raw.githubusercontent.com/ASankaran/core/master/data/",
+	"GITSTORE_BASE_URI":           "https://raw.githubusercontent.com/acm-uiuc/core/master/data/",
 	"GROUP_URI":                   "groups.yaml",
 	"HACKILLINOIS_URI":            "hackillinois.yaml",
 	"REFLECTIONSPROJECTIONS_URI":  "reflectionsprojections.yaml",


### PR DESCRIPTION
The gitstore uri was not updated when the repository was migrated to https://github.com/acm-uiuc/core.