### PR TITLE
Fix facilities typo

### DIFF
--- a/data/about.yaml
+++ b/data/about.yaml
@@ -34,7 +34,7 @@ content:
     of ACM is defined. Everyone is welcome to attend and make suggestions for
     new ACM groups or events. Decisions about such events and other important
     ACM matters are also made at these meetings.
-facilites:
+facilities:
   - location: 1104 Siebel
     name: The ACM Office
     description: >

--- a/model/about.go
+++ b/model/about.go
@@ -2,7 +2,7 @@ package model
 
 type About struct {
 	Content   []string     `yaml:"content"`
-	Facilites []Facility   `yaml:"facilites"`
+	Facilities []Facility   `yaml:"facilities"`
 	History   AboutHistory `yaml:"history"`
 	Links     []AboutLink  `yaml:"links"`
 }

--- a/model/about.go
+++ b/model/about.go
@@ -1,10 +1,10 @@
 package model
 
 type About struct {
-	Content   []string     `yaml:"content"`
-	Facilities []Facility   `yaml:"facilities"`
-	History   AboutHistory `yaml:"history"`
-	Links     []AboutLink  `yaml:"links"`
+	Content    []string     `yaml:"content"`
+	Facilities []Facility   `yaml:"facilites"`
+	History    AboutHistory `yaml:"history"`
+	Links      []AboutLink  `yaml:"links"`
 }
 
 type Facility struct {

--- a/template/about.html
+++ b/template/about.html
@@ -15,8 +15,8 @@
         <br>
     </div>
     <div class="row">
-        <h3>Facilites</h3>
-        {{range .About.Facilites}}
+        <h3>Facilities</h3>
+        {{range .About.Facilities}}
             <h4>{{.Location}} - {{.Name}}</h4>
             <p>{{.Description}}</p>
         {{end}}


### PR DESCRIPTION
Fixes typo: `facilites` => `facilities`