### PR TITLE
Add the ability to support multiple meeting times for SIGs (#28)

### DIFF
--- a/data/groups.yaml
+++ b/data/groups.yaml
@@ -102,126 +102,162 @@ sigs:
   - name: Gamebuilders
     description: Anything and everything related to game development
     chairs: Aditya Bawankule
-    meetingTime: 'Monday 7:00 PM - 8:30 PM'
-    meetingLocation: Siebel 3405
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Monday 7:00 PM - 8:30 PM'
+        meetingLocation: Siebel 3405
     website: http://gamebuilders.acm.illinois.edu/
     email: adityab2@illinois.edu
   - name: GLUG
     description: GNU/Linux Users Group
     chairs: Chinmaya Mahesh
-    meetingTime: 'Thursday 5:00 PM - 6:00 PM'
-    meetingLocation: Siebel 1109
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Thursday 5:00 PM - 6:00 PM'
+        meetingLocation: Siebel 1109
     website: http://lug.acm.illinois.edu
     email: glug@acm.illinois.org
   - name: ICPC
     description: Competitive programming skill development and competitions
     chairs: Nikil Ravi, Yen-Hsiang Chang
-    meetingTime: 'Tuesday 7:00 PM - 9:00 PM'
-    meetingLocation: Siebel 1109
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Tuesday 7:00 PM - 9:00 PM'
+        meetingLocation: Siebel 1109
     website: http://icpc.cs.illinois.edu/
     email: icpc@cs.illinois.edu
   - name: SIGBot
     description: Special Interest Group for Robotics
     chairs: Ananmay Jain
-    meetingTime: 'Saturday & Sunday 12:00 PM - 2:00 PM'
-    meetingLocation: Siebel 1104
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Saturday & Sunday 12:00 PM - 2:00 PM'
+        meetingLocation: Siebel 1104
     website: http://illinoisauv.com/
     email: ananmay3@illinois.edu
   - name: SIGCHI
     description: Special Interest Group for Human-Computer Interaction
     chairs: Jeffrey Tsai
-    meetingTime: 'Tuesday 5:00 PM - 7:00 PM'
-    meetingLocation: Siebel 1304
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Tuesday 5:00 PM - 7:00 PM'
+        meetingLocation: Siebel 1304
     website: http://sigchi.acm.illinois.edu/
     email: jeffrey5@illinois.edu
   - name: SIGGRAPH
     description: Special Interest Group for Graphics
     chairs: Sahil Patel
-    meetingTime: 'Monday 6:00 PM - 7:00 PM'
-    meetingLocation: Siebel 3401
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Monday 6:00 PM - 7:00 PM'
+        meetingLocation: Siebel 3401
     website: https://acm-uiuc.github.io/siggraph/
     email: siggraphuiuc@gmail.com
   - name: AIDA
     description: Artificial Intelligence and Data Analytics
     chairs: Jeffrey Lai, Arjun Gupta, Shaw Kagawa
-    meetingTime: 'Sunday 1:00 PM - 4:00 PM'
-    meetingLocation: Siebel 1105
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Sunday 1:00 PM - 4:00 PM'
+        meetingLocation: Siebel 1105
     website: https://aida.acm.illinois.edu
     email: sig-aida-request@lists.illinois.edu
   - name: QUIUC
     description: Special Interest Group for Quantum Computing
     chairs: Bailey Tincher, Graeme Jacobson
-    meetingTime: 'Sunday 2:00 PM - 3:00 PM'
-    meetingLocation: Siebel 1103
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Sunday 2:00 PM - 3:00 PM'
+        meetingLocation: Siebel 1103
     website: https://www.quiuc.org
     email: info@quiuc.org
   - name: SIGOPS
     description: Special Interest Group for Operating Systems
     chairs: Anshul Sanamvenkata, Chinmaya Mahesh, Kapil Kanwar
-    meetingTime: 'Saturday 12:00 PM - 2:00 PM'
-    meetingLocation: Siebel 1302
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Saturday 12:00 PM - 2:00 PM'
+        meetingLocation: Siebel 1302
     website: http://sigops.acm.illinois.edu
     email: anshul2@illinois.edu
   - name: SIGMobile
     description: Special Interest Group for Mobile Development
     chairs: Matt Geimer
-    meetingTime: 'Tuesday 5:00 PM - 6:00 PM'
-    meetingLocation: Siebel 1214
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Tuesday 5:00 PM - 6:00 PM'
+        meetingLocation: Siebel 1214
     website: http://github.com/SIGMobileUIUC
     email: mgeimer2@illinois.edu
   - name: SIGMusic
     description: Special Interest Group for Music
     chairs: Melissa Chen, Sahil Patel
-    meetingTime: 'Thursday 6:00 PM - 7:00 PM'
-    meetingLocation: Siebel 1109
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Thursday 6:00 PM - 7:00 PM'
+        meetingLocation: Siebel 1109
     website: http://sigmusic.acm.illinois.edu
     email: myc2@illinois.edu
   - name: SIGPwny
     description: Special Interest Group for Security
     chairs: Joseph Ravichandran
-    meetingTime: 'Thursday 6:00 PM - 7:00 PM'
-    meetingLocation: Siebel 1314
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Thursday 6:00 PM - 7:00 PM'
+        meetingLocation: Siebel 1314
     website: https://sigpwny.com
     email: jpr3@illinois.edu
   - name: SIGBlockchain
     description: Special Interest Group for Blockchain Technologies
     chairs: Jason Maldonado
-    meetingTime: 'Wednesday 5:00 PM - 6:00 PM'
-    meetingLocation: Siebel 1302
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Wednesday 5:00 PM - 6:00 PM'
+        meetingLocation: Siebel 1302
     website: ''
     email: jmaldo2@illinois.edu
   - name: SIGNLL
     description: Special Interest Group for Natural Language Learning
     chairs: Jack Nash, Nishant Balepur
-    meetingTime: 'Wednesday 5:30 PM - 6:30 PM'
-    meetingLocation: Siebel 1214
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Wednesday 5:30 PM - 6:30 PM'
+        meetingLocation: Siebel 1214
     website: https://www.facebook.com/groups/uiucsignll
     email: balepur2@illinois.edu
   - name: SIGArch
     description: Special Interest Group for Architecture
     chairs: Kris Koepcke
-    meetingTime: 'Tuesday 6:00 PM - 7:00 PM'
-    meetingLocation: Siebel 1214
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Tuesday 6:00 PM - 7:00 PM'
+        meetingLocation: Siebel 1214
     website: ''
     email: koepcke2@illinois.edu
   - name: SIGPlan
     description: Special Interest Group for Programming Languages
     chairs: Reed Oei
-    meetingTime: 'Sunday 4:00 PM - 5:00 PM'
-    meetingLocation: Siebel 2407
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Sunday 4:00 PM - 5:00 PM'
+        meetingLocation: Siebel 2407
     website: ''
     email: reedoei2@illinois.edu
   - name: SIGCloud
     description: Special Interest Group for Cloud Computing
     chairs: Shreyas Kishore
-    meetingTime: TBD
-    meetingLocation: TDB
+    meetings:
+      - topic: General Meeting
+        meetingTime: TBD
+        meetingLocation: TDB
     website: ''
     email: kishore4@illinois.edu
   - name: SIGHPC
     description: Special Interest Group for High-Performance Computing
     chairs: Jonathan Nativ
-    meetingTime: TBD
-    meetingLocation: TBD
+    meetings:
+      - topic: General Meeting
+        meetingTime: TBD
+        meetingLocation: TBD
     website: ''
     email: jnativ2@illinois.edu

--- a/model/group.go
+++ b/model/group.go
@@ -1,14 +1,19 @@
 package model
 
 type Group struct {
-	Name            string        `yaml:"name"`
-	Description     string        `yaml:"description"`
-	Chairs          string        `yaml:"chairs"`
-	Members         []GroupMember `yaml:"members"`
-	MeetingTime     string        `yaml:"meetingTime"`
-	MeetingLocation string        `yaml:"meetingLocation"`
-	Website         string        `yaml:"website"`
-	Email           string        `yaml:"email"`
+	Name        string        `yaml:"name"`
+	Description string        `yaml:"description"`
+	Chairs      string        `yaml:"chairs"`
+	Meetings    []Meeting     `yaml:"meetings"`
+	Members     []GroupMember `yaml:"members"`
+	Website     string        `yaml:"website"`
+	Email       string        `yaml:"email"`
+}
+
+type Meeting struct {
+	Topic           string `yaml:"topic"`
+	MeetingTime     string `yaml:"meetingTime"`
+	MeetingLocation string `yaml:"meetingLocation"`
 }
 
 type GroupMember struct {

--- a/template/sigs.html
+++ b/template/sigs.html
@@ -16,10 +16,15 @@
                                   {{.Description}}
                               </span>
                               <br/>
-                              <span>
-                                  <b> {{.MeetingTime}} </b> - {{.MeetingLocation}}
-                              </span>
-                              <br/>
+                              <ul>
+                                {{ range .Meetings }}
+                                  <li>
+                                    <b>{{.Topic}}</b>
+                                    <br />
+                                    {{.MeetingTime}} - {{.MeetingLocation}}
+                                  </li>
+                                {{end}}
+                              </ul>
                               <span>
                                   <i> Chair(s) </i> - <b> {{.Chairs}} </b>
                               </span>
@@ -46,10 +51,15 @@
                                 {{.Description}}
                             </span>
                             <br/>
-                            <span>
-                                <b> {{.MeetingTime}} </b> - {{.MeetingLocation}}
-                            </span>
-                            <br/>
+                            <ul>
+                              {{ range .Meetings }}
+                                <li>
+                                  <b>{{.Topic}}</b>
+                                  <br />
+                                  {{.MeetingTime}} - {{.MeetingLocation}}
+                                </li>
+                              {{end}}
+                            </ul>
                             <span>
                                 <i> Chair(s) </i> - <b> {{.Chairs}} </b>
                             </span>

--- a/test/data/groups.yaml
+++ b/test/data/groups.yaml
@@ -76,112 +76,144 @@ sigs:
   - name: Gamebuilders
     description: Anything and everything related to game development
     chairs: Aditya Bawankule
-    meetingTime: 'Monday 7:00 PM - 8:30 PM'
-    meetingLocation: Siebel 3405
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Monday 7:00 PM - 8:30 PM'
+        meetingLocation: Siebel 3405
     website: http://gamebuilders.acm.illinois.edu/
     email: adityab2@illinois.edu
   - name: GLUG
     description: GNU/Linux Users Group
     chairs: Jav Mohamed
-    meetingTime: 'Thursday 5:00 PM - 6:00 PM'
-    meetingLocation: Siebel 1109
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Thursday 5:00 PM - 6:00 PM'
+        meetingLocation: Siebel 1109
     website: http://gnulug.org
     email: glug@acm.illinois.org
   - name: ICPC
     description: Competitive programming skill development and competitions
     chairs: Vivek Gupta, Eric Wang
-    meetingTime: 'Tuesday 7:00 PM - 9:00 PM'
-    meetingLocation: Siebel 1109
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Tuesday 7:00 PM - 9:00 PM'
+        meetingLocation: Siebel 1109
     website: http://icpc.cs.illinois.edu/
     email: icpc@cs.illinois.edu
   - name: SIGBot
     description: Special Interest Group for Robotics
     chairs: Ananmay Jain
-    meetingTime: 'Saturday & Sunday 12:00 PM - 2:00 PM'
-    meetingLocation: Siebel 1104
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Saturday & Sunday 12:00 PM - 2:00 PM'
+        meetingLocation: Siebel 1104
     website: http://illinoisauv.com/
     email: ananmay3@illinois.edu
   - name: SIGCHI
     description: Special Interest Group for Human-Computer Interaction
     chairs: Jeffrey Tsai
-    meetingTime: 'Tuesday 5:00 PM - 7:00 PM'
-    meetingLocation: Siebel 1304
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Tuesday 5:00 PM - 7:00 PM'
+        meetingLocation: Siebel 1304
     website: http://sigchi.acm.illinois.edu/
     email: jeffrey5@illinois.edu
   - name: SIGGRAPH
     description: Special Interest Group for Graphics
     chairs: Chen Qian
-    meetingTime: 'Monday 6:00 PM - 7:00 PM'
-    meetingLocation: Siebel 3401
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Monday 6:00 PM - 7:00 PM'
+        meetingLocation: Siebel 3401
     website: https://acm-uiuc.github.io/siggraph/
     email: siggraphuiuc@gmail.com
   - name: AIDA
     description: Artificial Intelligence and Data Analytics
     chairs: Jeffrey Lai, Arjun Gupta, Shaw Kagawa
-    meetingTime: 'Sunday 1:00 PM - 4:00 PM'
-    meetingLocation: Siebel 1105
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Sunday 1:00 PM - 4:00 PM'
+        meetingLocation: Siebel 1105
     website: https://aida.acm.illinois.edu
     email: sig-aida-request@lists.illinois.edu
   - name: QUIUC
     description: Special Interest Group for Quantum Computing
     chairs: Bailey Tincher, Graeme Jacobson
-    meetingTime: 'Sunday 2:00 PM - 3:00 PM'
-    meetingLocation: Siebel 1103
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Sunday 2:00 PM - 3:00 PM'
+        meetingLocation: Siebel 1103
     website: https://www.quiuc.org
     email: info@quiuc.org
   - name: SIGOPS
     description: Special Interest Group for Operating Systems
     chairs: Anshul Sanamvenkata, Chinmaya Mahesh, Kapil Kanwar
-    meetingTime: 'Saturday 12:00 PM - 2:00 PM'
-    meetingLocation: Siebel 1302
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Saturday 12:00 PM - 2:00 PM'
+        meetingLocation: Siebel 1302
     website: http://sigops.acm.illinois.edu
     email: anshul2@illinois.edu
   - name: SIGMobile
     description: Special Interest Group for Mobile Development
     chairs: Patrick Feltes
-    meetingTime: 'Tuesday 5:00 PM - 6:00 PM'
-    meetingLocation: Siebel 1214
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Tuesday 5:00 PM - 6:00 PM'
+        meetingLocation: Siebel 1214
     website: http://github.com/SIGMobileUIUC
     email: pfeltes2@illinois.edu
   - name: SIGMusic
     description: Special Interest Group for Music
     chairs: Melissa Chen, Sahil Patel
-    meetingTime: 'Thursday 6:00 PM - 7:00 PM'
-    meetingLocation: Siebel 1109
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Thursday 6:00 PM - 7:00 PM'
+        meetingLocation: Siebel 1109
     website: http://sigmusic.acm.illinois.edu
     email: myc2@illinois.edu
   - name: SIGPwny
     description: Special Interest Group for Security
     chairs: Joseph Ravichandran
-    meetingTime: 'Thursday 6:00 PM - 7:00 PM'
-    meetingLocation: Siebel 1314
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Thursday 6:00 PM - 7:00 PM'
+        meetingLocation: Siebel 1314
     website: https://sigpwny.com
     email: jpr3@illinois.edu
   - name: SIGBlockchain
     description: Special Interest Group for Blockchain Technologies
     chairs: Jason Maldonado
-    meetingTime: 'Wednesday 5:00 PM - 6:00 PM'
-    meetingLocation: Siebel 1302
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Wednesday 5:00 PM - 6:00 PM'
+        meetingLocation: Siebel 1302
     website: ''
     email: jmaldo2@illinois.edu
   - name: SIGNLL
     description: Special Interest Group for Natural Language Learning
     chairs: Jackie Oh, Jason Xia
-    meetingTime: 'Wednesday 5:30 PM - 6:30 PM'
-    meetingLocation: Siebel 1214
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Wednesday 5:30 PM - 6:30 PM'
+        meetingLocation: Siebel 1214
     website: https://www.facebook.com/groups/uiucsignll
     email: jmoh3@illinois.edu
   - name: SIGArch
     desription: Special Interest Group for Architecture
     chairs: Kris Koepcke
-    meetingTime: 'Tuesday 6:00 PM - 7:00 PM'
-    meetingLocation: Siebel 1214
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Tuesday 6:00 PM - 7:00 PM'
+        meetingLocation: Siebel 1214
     website: ''
     email: koepcke2@illinois.edu
   - name: SIGPlan
     description: Special Interest Group for Programming Languages
     chairs: Reed Oei
-    meetingTime: 'Sunday 4:00 PM - 5:00 PM'
-    meetingLocation: Siebel 2407
+    meetings:
+      - topic: General Meeting
+        meetingTime: 'Sunday 4:00 PM - 5:00 PM'
+        meetingLocation: Siebel 2407
     website: ''
     email: reedoei2@illinois.edu


### PR DESCRIPTION
Close #28 

You can add multiple meeting times for a SIG in `groups.yaml` in the format:
```
meetings:
  - topic: General Meeting
    meetingTime: 'Thursday 5:00 PM - 6:00 PM'
    meetingLocation: Siebel 1109
```

 They will then show up on the `sigs.html` page.