### PR TITLE
Merge hackthis into hackillinois page

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,6 @@ var defaultConfig = map[string]string{
 	"GITSTORE_BASE_URI":           "https://raw.githubusercontent.com/acm-uiuc/core/master/data/",
 	"GROUP_URI":                   "groups.yaml",
 	"HACKILLINOIS_URI":            "hackillinois.yaml",
-	"HACKTHIS_URI":                "hackthis.yaml",
 	"REFLECTIONSPROJECTIONS_URI":  "reflectionsprojections.yaml",
 	"INTRANET_URI":                "intranet.yaml",
 	"SPONSORS_URI":                "sponsors.yaml",

--- a/template/header.html
+++ b/template/header.html
@@ -133,9 +133,6 @@
                             <a href="/hackillinois">HackIllinois</a>
                         </li>
                         <li class="nav-loc-side">
-                            <a href="/hackthis">HackThis</a>
-                        </li>
-                        <li class="nav-loc-side">
                             <a href="/sponsors">Sponsors</a>
                         </li>
                         {{if not .Authenticated}}


### PR DESCRIPTION
- Remove stale 404 link & config value


Resolves this task:

```
HackThis’s link from sidebar has a 404 Error (maybe get rid of it since HackThis info is on the HackIllinois page)
http://acm.illinois.edu/hackthis
```