### PR TITLE
fix history page footer

### DIFF
--- a/template/header.html
+++ b/template/header.html
@@ -53,6 +53,9 @@
                                 <a href="/about"> About </a>
                             </li>
                             <li class="nav-loc">
+                                <a href="/about/history">History</a>
+                            </li>
+                            <li class="nav-loc">
                                 <a href="/sigs">SIGs</a>
                             </li>
                             <li class="nav-loc">
@@ -122,6 +125,9 @@
                         </li>
                         <li class="nav-loc-side">
                             <a href="/about"> About </a>
+                        </li>
+                        <li class="nav-loc-side">
+                            <a href="/about/history">History</a>
                         </li>
                         <li class="nav-loc-side">
                             <a href="/sigs">SIGs</a>

--- a/template/history.html
+++ b/template/history.html
@@ -1,7 +1,7 @@
 {{define "history"}}
 {{template "header" .}}
 
-<div class="history-container">
+<div class="container history-container">
     <div class="row">
         <h1>About ACM@UIUC</h1>
     </div>


### PR DESCRIPTION
Fixed the [history page](https://acm.illinois.edu/about/history)'s footer so it is no longer squished.

Before:
<img width="1587" alt="Screen Shot 2021-07-08 at 10 06 27 PM" src="https://user-images.githubusercontent.com/22971700/125017435-c1413a80-e038-11eb-8286-bada2a614422.png">
After:
<img width="1587" alt="Screen Shot 2021-07-08 at 10 06 43 PM" src="https://user-images.githubusercontent.com/22971700/125017453-ca320c00-e038-11eb-88b1-c8e88fefe179.png">
