### PR TITLE
Convert NetIDs to lowercase when checking membership

### DIFF
--- a/src/api/routes/membership.ts
+++ b/src/api/routes/membership.ts
@@ -9,6 +9,7 @@ import { FastifyPluginAsync } from "fastify";
 import {
   BaseError,
   InternalServerError,
+  NotImplementedError,
   ValidationError,
 } from "common/errors/index.js";
 import { getEntraIdToken } from "api/functions/entraId.js";
@@ -23,6 +24,7 @@ import stripe, { Stripe } from "stripe";
 import { AvailableSQSFunctions, SQSPayload } from "common/types/sqsMessage.js";
 import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
 import rawbody, { RawBodyPluginOptions } from "fastify-raw-body";
+import { ListModificationPatchRequest } from "common/types/membership.js";
 
 const NONMEMBER_CACHE_SECONDS = 1800; // 30 minutes
 const MEMBER_CACHE_SECONDS = 43200; // 12 hours
@@ -73,7 +75,7 @@ const membershipPlugin: FastifyPluginAsync = async (fastify, _options) => {
       Body: undefined;
       Params: { netId: string };
     }>("/checkout/:netId", async (request, reply) => {
-      const netId = request.params.netId;
+      const netId = request.params.netId.toLowerCase();
       if (!validateNetId(netId)) {
         throw new ValidationError({
           message: `${netId} is not a valid Illinois NetID!`,
@@ -147,7 +149,7 @@ const membershipPlugin: FastifyPluginAsync = async (fastify, _options) => {
       Querystring: { list?: string };
       Params: { netId: string };
     }>("/:netId", async (request, reply) => {
-      const netId = request.params.netId;
+      const netId = request.params.netId.toLowerCase();
       const list = request.query.list || "acmpaid";
       if (!validateNetId(netId)) {
         throw new ValidationError({

--- a/src/api/routes/membership.ts
+++ b/src/api/routes/membership.ts
@@ -9,22 +9,20 @@ import { FastifyPluginAsync } from "fastify";
 import {
   BaseError,
   InternalServerError,
-  NotImplementedError,
   ValidationError,
 } from "common/errors/index.js";
 import { getEntraIdToken } from "api/functions/entraId.js";
 import { genericConfig, roleArns } from "common/config.js";
 import { getRoleCredentials } from "api/functions/sts.js";
 import { SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
-import { DynamoDBClient, QueryCommand } from "@aws-sdk/client-dynamodb";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import rateLimiter from "api/plugins/rateLimiter.js";
 import { createCheckoutSession } from "api/functions/stripe.js";
 import { getSecretValue } from "api/plugins/auth.js";
 import stripe, { Stripe } from "stripe";
 import { AvailableSQSFunctions, SQSPayload } from "common/types/sqsMessage.js";
 import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
-import rawbody, { RawBodyPluginOptions } from "fastify-raw-body";
-import { ListModificationPatchRequest } from "common/types/membership.js";
+import rawbody from "fastify-raw-body";
 
 const NONMEMBER_CACHE_SECONDS = 1800; // 30 minutes
 const MEMBER_CACHE_SECONDS = 43200; // 12 hours

--- a/tests/live/membership.test.ts
+++ b/tests/live/membership.test.ts
@@ -21,6 +21,30 @@ describe("Membership API basic checks", async () => {
     expect(wasCached(response.headers.get("x-acm-data-source"))).toBe(true);
   });
   test(
+    "Test that getting member with non-standard casing succeeds",
+    { timeout: 3000 },
+    async () => {
+      const response = await fetch(
+        `${baseEndpoint}/api/v1/membership/DSingh14`,
+        {
+          method: "GET",
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody).toStrictEqual({
+        netId: "dsingh14",
+        isPaidMember: true,
+      });
+
+      const wasCached = (value: string | null) => value && value !== "aad";
+
+      expect(wasCached(response.headers.get("x-acm-data-source"))).toBe(true);
+    },
+  );
+  test(
     "Test that getting non-members succeeds",
     { timeout: 3000 },
     async () => {


### PR DESCRIPTION
Fixes a long-standing bug in both the new and old membership API. Can't rely on the client to lowercase.