### PR TITLE
fix: remove empty security array from tickets plugin schema

### DIFF
--- a/src/api/routes/tickets.ts
+++ b/src/api/routes/tickets.ts
@@ -212,7 +212,6 @@ const ticketsPlugin: FastifyPluginAsync = async (fastify, _options) => {
           params: z.object({
             eventId: z.string().min(1),
           }),
-          security: [],
         }),
       ),
       onRequest: fastify.authorizeFromSchema,


### PR DESCRIPTION
* Ensure that the swagger schema correctly reflects auth on the event ID tickets route.