### PR TITLE
Reorganize Live and E2E tests

### DIFF
--- a/tests/e2e/base.ts
+++ b/tests/e2e/base.ts
@@ -1,4 +1,4 @@
-import { test as base } from "@playwright/test";
+import { test as base, Page } from "@playwright/test";
 import {
   SecretsManagerClient,
   GetSecretValueCommand,
@@ -7,7 +7,9 @@ import {
 export const getSecretValue = async (
   secretId: string,
 ): Promise<Record<string, string | number | boolean> | null> => {
-  const smClient = new SecretsManagerClient();
+  const smClient = new SecretsManagerClient({
+    region: process.env.AWS_REGION ?? "us-east-1",
+  });
   const data = await smClient.send(
     new GetSecretValueCommand({ SecretId: secretId }),
   );
@@ -32,10 +34,10 @@ async function getSecrets() {
   }
   response["PLAYWRIGHT_USERNAME"] =
     process.env.PLAYWRIGHT_USERNAME ||
-    (keyData ? keyData["playwright_username"] : "");
+    ((keyData ? keyData["playwright_username"] : "") as string);
   response["PLAYWRIGHT_PASSWORD"] =
     process.env.PLAYWRIGHT_PASSWORD ||
-    (keyData ? keyData["playwright_password"] : "");
+    ((keyData ? keyData["playwright_password"] : "") as string);
   return response;
 }
 
@@ -45,7 +47,7 @@ export function capitalizeFirstLetter(string: string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-async function becomeUser(page) {
+async function becomeUser(page: Page) {
   await page.goto("https://core.aws.qa.acmuiuc.org/login");
   await page
     .getByRole("button", { name: "Sign in with Illinois NetID" })
@@ -73,7 +75,7 @@ export async function getAllEvents() {
   return (await data.json()) as Record<string, string>[];
 }
 
-export const test = base.extend<{ becomeUser: (page) => Promise<void> }>({
+export const test = base.extend<{ becomeUser: (page: Page) => Promise<void> }>({
   becomeUser: async ({}, use) => {
     use(becomeUser);
   },

--- a/tests/live/apiKey.test.ts
+++ b/tests/live/apiKey.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, describe } from "vitest";
+import { getBaseEndpoint } from "./utils.js";
 
-const baseEndpoint = `https://core.aws.qa.acmuiuc.org`;
+const baseEndpoint = getBaseEndpoint();
 
 describe("API Key tests", async () => {
   test("Test that auth is present on routes", { timeout: 10000 }, async () => {

--- a/tests/live/documentation.test.ts
+++ b/tests/live/documentation.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
+import { getBaseEndpoint } from "./utils.js";
 
-const baseEndpoint = `https://core.aws.qa.acmuiuc.org`;
+const baseEndpoint = getBaseEndpoint();
 
 test("Get OpenAPI JSON", async () => {
   const response = await fetch(`${baseEndpoint}/api/documentation/json`);

--- a/tests/live/events.test.ts
+++ b/tests/live/events.test.ts
@@ -2,8 +2,10 @@ import { expect, test } from "vitest";
 import { EventsGetResponse } from "../../src/api/routes/events.js";
 import { createJwt } from "./utils.js";
 import { describe } from "node:test";
+import { getBaseEndpoint } from "./utils.js";
 
-const baseEndpoint = `https://core.aws.qa.acmuiuc.org`;
+const baseEndpoint = getBaseEndpoint();
+
 test("getting events", async () => {
   const response = await fetch(`${baseEndpoint}/api/v1/events`);
   expect(response.status).toBe(200);

--- a/tests/live/healthz.test.ts
+++ b/tests/live/healthz.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
-import { InternalServerError } from "../../src/common/errors/index.js";
+import { getBaseEndpoint } from "./utils.js";
 
-const baseEndpoint = `https://core.aws.qa.acmuiuc.org`;
+const baseEndpoint = getBaseEndpoint();
 
 test("healthz", async () => {
   const response = await fetch(`${baseEndpoint}/api/v1/healthz`);

--- a/tests/live/iam.test.ts
+++ b/tests/live/iam.test.ts
@@ -5,8 +5,9 @@ import {
   GroupMemberGetResponse,
 } from "../../src/common/types/iam.js";
 import { allAppRoles, AppRoles } from "../../src/common/roles.js";
+import { getBaseEndpoint } from "./utils.js";
 
-const baseEndpoint = `https://core.aws.qa.acmuiuc.org`;
+const baseEndpoint = getBaseEndpoint();
 test("getting members of a group", async () => {
   const token = await createJwt();
   const response = await fetch(

--- a/tests/live/ical.test.ts
+++ b/tests/live/ical.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "vitest";
 import { CoreOrganizationList } from "@acm-uiuc/js-shared";
 import ical from "node-ical";
-const baseEndpoint = `https://core.aws.qa.acmuiuc.org`;
+import { getBaseEndpoint } from "./utils.js";
+const baseEndpoint = getBaseEndpoint();
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/tests/live/linrky.test.ts
+++ b/tests/live/linrky.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "vitest";
+import { getBaseEndpoint, makeRandomString } from "./utils.js";
+
+const baseEndpoint = getBaseEndpoint("go");
+
+describe("Linkry live tests", async () => {
+  test("Linkry health check", async () => {
+    const response = await fetch(`${baseEndpoint}/healthz`);
+    expect(response.status).toBe(200);
+    expect(response.redirected).toBe(true);
+    expect(response.url).toBe("https://www.google.com/");
+  });
+  test("Linkry 404 redirect", async () => {
+    const response = await fetch(`${baseEndpoint}/${makeRandomString(16)}`);
+    expect(response.status).toBe(200);
+    expect(response.redirected).toBe(true);
+    expect(response.url).toBe("https://www.acm.illinois.edu/404");
+  });
+});

--- a/tests/live/membership.test.ts
+++ b/tests/live/membership.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, describe } from "vitest";
+import { getBaseEndpoint } from "./utils.js";
 
-const baseEndpoint = `https://core.aws.qa.acmuiuc.org`;
+const baseEndpoint = getBaseEndpoint();
 
 describe("Membership API basic checks", async () => {
   test("Test that getting member succeeds", { timeout: 3000 }, async () => {

--- a/tests/live/mobileWallet.test.ts
+++ b/tests/live/mobileWallet.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, describe } from "vitest";
+import { getBaseEndpoint } from "./utils.js";
 
-const baseEndpoint = `https://core.aws.qa.acmuiuc.org`;
+const baseEndpoint = getBaseEndpoint();
 
 describe("Mobile pass issuance", async () => {
   test(

--- a/tests/live/organizations.test.ts
+++ b/tests/live/organizations.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
-import { InternalServerError } from "../../src/common/errors/index.js";
+import { getBaseEndpoint } from "./utils.js";
 
-const baseEndpoint = `https://core.aws.qa.acmuiuc.org`;
+const baseEndpoint = getBaseEndpoint();
 
 test("getting organizations", async () => {
   const response = await fetch(`${baseEndpoint}/api/v1/organizations`);

--- a/tests/live/protected.test.ts
+++ b/tests/live/protected.test.ts
@@ -1,8 +1,9 @@
 import { expect, test, describe } from "vitest";
-import { createJwt } from "./utils";
-import { allAppRoles } from "../../src/common/roles";
+import { createJwt } from "./utils.js";
+import { allAppRoles } from "../../src/common/roles.js";
+import { getBaseEndpoint } from "./utils.js";
 
-const baseEndpoint = `https://core.aws.qa.acmuiuc.org`;
+const baseEndpoint = getBaseEndpoint();
 
 describe("Role checking live API tests", async () => {
   const token = await createJwt();

--- a/tests/live/stripe.test.ts
+++ b/tests/live/stripe.test.ts
@@ -1,7 +1,8 @@
 import { expect, test, describe } from "vitest";
-import { createJwt } from "./utils";
+import { createJwt } from "./utils.js";
+import { getBaseEndpoint } from "./utils.js";
 
-const baseEndpoint = `https://core.aws.qa.acmuiuc.org`;
+const baseEndpoint = getBaseEndpoint();
 
 describe("Stripe live API authentication", async () => {
   const token = await createJwt();

--- a/tests/live/tickets.test.ts
+++ b/tests/live/tickets.test.ts
@@ -1,7 +1,8 @@
 import { expect, test, describe } from "vitest";
-import { createJwt } from "./utils";
+import { createJwt } from "./utils.js";
+import { getBaseEndpoint } from "./utils.js";
 
-const baseEndpoint = `https://core.aws.qa.acmuiuc.org`;
+const baseEndpoint = getBaseEndpoint();
 
 describe("Tickets live API tests", async () => {
   const token = await createJwt();

--- a/tests/live/utils.ts
+++ b/tests/live/utils.ts
@@ -33,7 +33,7 @@ async function getSecrets() {
     keyData = await getSecretValue("infra-core-api-config");
   }
   response["JWTKEY"] =
-    process.env.JWT_KEY || (keyData ? keyData["jwt_key"] : "");
+    process.env.JWT_KEY || ((keyData ? keyData["jwt_key"] : "") as string);
   return response;
 }
 
@@ -69,4 +69,30 @@ export async function createJwt(
   };
   const token = jwt.sign(payload, secretData.JWTKEY, { algorithm: "HS256" });
   return token;
+}
+
+type Service = "core" | "go" | "ical";
+
+export function getBaseEndpoint(service?: Service) {
+  const base = process.env.CORE_BASE_URL ?? "https://core.aws.qa.acmuiuc.org";
+  if (
+    base.includes("localhost") ||
+    base.includes("127.0.0.1") ||
+    base.includes("::1") ||
+    !service
+  ) {
+    return base;
+  }
+  return base.replace("core", service);
+}
+
+export function makeRandomString(length: number) {
+  var result = "";
+  var characters =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  var charactersLength = characters.length;
+  for (var i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+  }
+  return result;
 }

--- a/tests/unit/logs.test.ts
+++ b/tests/unit/logs.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, expect, test, beforeEach, vi } from "vitest";
+import init from "../../src/api/index.js";
+import { describe } from "node:test";
+import { mockClient } from "aws-sdk-client-mock";
+import { DynamoDBClient, QueryCommand } from "@aws-sdk/client-dynamodb";
+import { secretObject } from "./secret.testdata.js";
+import supertest from "supertest";
+import { createJwt } from "./auth.test.js";
+import { genericConfig } from "../../src/common/config.js";
+import { marshall } from "@aws-sdk/util-dynamodb";
+import { Modules } from "../../src/common/modules.js";
+
+const ddbMock = mockClient(DynamoDBClient);
+const jwt_secret = secretObject["jwt_key"];
+vi.stubEnv("JwtSigningKey", jwt_secret);
+
+const app = await init();
+describe("Audit Log tests", async () => {
+  test("Sad path: Not authenticated", async () => {
+    await app.ready();
+    const response = await supertest(app.server)
+      .get("/api/v1/logs/events")
+      .send();
+    expect(response.statusCode).toBe(403);
+  });
+  test("Sad path: Authenticated but not authorized", async () => {
+    await app.ready();
+    const testJwt = createJwt(undefined, ["1"]);
+    const response = await supertest(app.server)
+      .get("/api/v1/logs/events?start=0&end=1")
+      .set("Authorization", `Bearer ${testJwt}`)
+      .send();
+    expect(response.statusCode).toBe(401);
+  });
+  test("Sad path: No start and end provided", async () => {
+    await app.ready();
+    const testJwt = createJwt(undefined, ["0"]);
+    const response = await supertest(app.server)
+      .get("/api/v1/logs/events")
+      .set("Authorization", `Bearer ${testJwt}`)
+      .send();
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toStrictEqual({
+      error: true,
+      name: "ValidationError",
+      id: 104,
+      message:
+        "querystring/start Expected number, received nan, querystring/end Expected number, received nan",
+    });
+  });
+  test("Sad path: Items is undefined", async () => {
+    const logEntry = {
+      module: Modules.EVENTS,
+      actor: "me",
+      target: "you",
+      requestId: "c03ddefa-11d7-4b7c-a6d5-771460e1b45f",
+      message: "no!",
+    };
+    ddbMock
+      .on(QueryCommand, {
+        TableName: genericConfig.AuditLogTable,
+        KeyConditionExpression: "#pk = :module AND #sk BETWEEN :start AND :end",
+        ExpressionAttributeNames: {
+          "#pk": "module",
+          "#sk": "createdAt",
+        },
+        ExpressionAttributeValues: {
+          ":module": { S: "events" },
+          ":start": { N: "1750349770" },
+          ":end": { N: "1750436176" },
+        },
+      })
+      .resolvesOnce({
+        Items: [marshall(logEntry)],
+      });
+    await app.ready();
+    const testJwt = createJwt(undefined, ["0"]);
+    const response = await supertest(app.server)
+      .get("/api/v1/logs/events?start=1750349770&end=1750436176")
+      .set("Authorization", `Bearer ${testJwt}`)
+      .send();
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toStrictEqual([logEntry]);
+  });
+  ddbMock
+    .on(QueryCommand, {
+      TableName: genericConfig.AuditLogTable,
+      KeyConditionExpression: "#pk = :module AND #sk BETWEEN :start AND :end",
+      ExpressionAttributeNames: {
+        "#pk": "module",
+        "#sk": "createdAt",
+      },
+      ExpressionAttributeValues: {
+        ":module": { S: "events" },
+        ":start": { N: "1750349770" },
+        ":end": { N: "1750436176" },
+      },
+    })
+    .resolvesOnce({
+      Items: undefined,
+    });
+  await app.ready();
+  const testJwt = createJwt(undefined, ["0"]);
+  const response = await supertest(app.server)
+    .get("/api/v1/logs/events?start=1750349770&end=1750436176")
+    .set("Authorization", `Bearer ${testJwt}`)
+    .send();
+  expect(response.statusCode).toBe(500);
+});
+afterAll(async () => {
+  await app.close();
+});
+beforeEach(() => {
+  (app as any).nodeCache.flushAll();
+  (app as any).redisClient.flushdb();
+  ddbMock.reset();
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+});

--- a/tests/unit/vitest.config.ts
+++ b/tests/unit/vitest.config.ts
@@ -12,6 +12,11 @@ export default defineConfig({
       provider: "istanbul",
       include: ["src/api/**/*.ts", "src/common/**/*.ts"],
       exclude: ["src/api/lambda.ts"],
+      thresholds: {
+        statements: 54,
+        functions: 65,
+        lines: 54,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
* FIx Playwright base typing issues
* Create linkry exists and not-exists tests.
* Use `getBaseEndpoint()` function to allow us to run live tests on different endpoints.