### PR TITLE
Change membership caching behavior

### DIFF
--- a/src/api/functions/membership.ts
+++ b/src/api/functions/membership.ts
@@ -16,6 +16,8 @@ import { EntraGroupError } from "common/errors/index.js";
 import { EntraGroupActions } from "common/types/iam.js";
 import { pollUntilNoError } from "./general.js";
 
+export const MEMBER_CACHE_SECONDS = 43200; // 12 hours
+
 export async function checkExternalMembership(
   netId: string,
   list: string,

--- a/src/api/routes/membership.ts
+++ b/src/api/routes/membership.ts
@@ -3,6 +3,7 @@ import {
   checkPaidMembershipFromEntra,
   checkPaidMembershipFromTable,
   setPaidMembershipInTable,
+  MEMBER_CACHE_SECONDS,
 } from "api/functions/membership.js";
 import { validateNetId } from "api/functions/validation.js";
 import { FastifyPluginAsync } from "fastify";
@@ -26,9 +27,7 @@ import rawbody from "fastify-raw-body";
 import { FastifyZodOpenApiTypeProvider } from "fastify-zod-openapi";
 import { z } from "zod";
 import { withTags } from "api/components/index.js";
-
-const NONMEMBER_CACHE_SECONDS = 60; // 1 minute
-const MEMBER_CACHE_SECONDS = 43200; // 12 hours
+import { getKey, setKey } from "api/functions/redisCache.js";
 
 const membershipPlugin: FastifyPluginAsync = async (fastify, _options) => {
   await fastify.register(rawbody, {
@@ -134,11 +133,7 @@ const membershipPlugin: FastifyPluginAsync = async (fastify, _options) => {
             message: `${netId} is already a paid member!`,
           });
         }
-        fastify.nodeCache.set(
-          `isMember_${netId}`,
-          false,
-          NONMEMBER_CACHE_SECONDS,
-        );
+        fastify.nodeCache.set(`isMember_${netId}`, false, MEMBER_CACHE_SECONDS);
         const secretApiConfig =
           (await getSecretValue(
             fastify.secretsManagerClient,
@@ -190,11 +185,17 @@ const membershipPlugin: FastifyPluginAsync = async (fastify, _options) => {
       async (request, reply) => {
         const netId = request.params.netId.toLowerCase();
         const list = request.query.list || "acmpaid";
-        if (fastify.nodeCache.get(`isMember_${netId}_${list}`) !== undefined) {
+        const cacheKey = `membership:${netId}:${list}`;
+        const result = await getKey<{ isMember: boolean }>({
+          redisClient: fastify.redisClient,
+          key: cacheKey,
+          logger: request.log,
+        });
+        if (result) {
           return reply.header("X-ACM-Data-Source", "cache").send({
             netId,
             list: list === "acmpaid" ? undefined : list,
-            isPaidMember: fastify.nodeCache.get(`isMember_${netId}_${list}`),
+            isPaidMember: result.isMember,
           });
         }
         if (list !== "acmpaid") {
@@ -203,11 +204,13 @@ const membershipPlugin: FastifyPluginAsync = async (fastify, _options) => {
             list,
             fastify.dynamoClient,
           );
-          fastify.nodeCache.set(
-            `isMember_${netId}_${list}`,
-            isMember,
-            MEMBER_CACHE_SECONDS,
-          );
+          await setKey({
+            redisClient: fastify.redisClient,
+            key: cacheKey,
+            data: JSON.stringify({ isMember }),
+            expiresIn: MEMBER_CACHE_SECONDS,
+            logger: request.log,
+          });
           return reply.header("X-ACM-Data-Source", "dynamo").send({
             netId,
             list,
@@ -219,11 +222,13 @@ const membershipPlugin: FastifyPluginAsync = async (fastify, _options) => {
           fastify.dynamoClient,
         );
         if (isDynamoMember) {
-          fastify.nodeCache.set(
-            `isMember_${netId}_${list}`,
-            true,
-            MEMBER_CACHE_SECONDS,
-          );
+          await setKey({
+            redisClient: fastify.redisClient,
+            key: cacheKey,
+            data: JSON.stringify({ isMember: true }),
+            expiresIn: MEMBER_CACHE_SECONDS,
+            logger: request.log,
+          });
           return reply
             .header("X-ACM-Data-Source", "dynamo")
             .send({ netId, isPaidMember: true });
@@ -241,22 +246,26 @@ const membershipPlugin: FastifyPluginAsync = async (fastify, _options) => {
           paidMemberGroup,
         );
         if (isAadMember) {
-          fastify.nodeCache.set(
-            `isMember_${netId}_${list}`,
-            true,
-            MEMBER_CACHE_SECONDS,
-          );
+          await setKey({
+            redisClient: fastify.redisClient,
+            key: cacheKey,
+            data: JSON.stringify({ isMember: true }),
+            expiresIn: MEMBER_CACHE_SECONDS,
+            logger: request.log,
+          });
           reply
             .header("X-ACM-Data-Source", "aad")
             .send({ netId, isPaidMember: true });
           await setPaidMembershipInTable(netId, fastify.dynamoClient);
           return;
         }
-        fastify.nodeCache.set(
-          `isMember_${netId}_${list}`,
-          false,
-          NONMEMBER_CACHE_SECONDS,
-        );
+        await setKey({
+          redisClient: fastify.redisClient,
+          key: cacheKey,
+          data: JSON.stringify({ isMember: false }),
+          expiresIn: MEMBER_CACHE_SECONDS,
+          logger: request.log,
+        });
         return reply
           .header("X-ACM-Data-Source", "aad")
           .send({ netId, isPaidMember: false });
@@ -315,6 +324,7 @@ const membershipPlugin: FastifyPluginAsync = async (fastify, _options) => {
           ) {
             const customerEmail = event.data.object.customer_email;
             if (!customerEmail) {
+              request.log.info("No customer email found.");
               return reply
                 .code(200)
                 .send({ handled: false, requestId: request.id });

--- a/src/api/sqs/handlers/provisionNewMember.ts
+++ b/src/api/sqs/handlers/provisionNewMember.ts
@@ -1,13 +1,18 @@
 import { AvailableSQSFunctions } from "common/types/sqsMessage.js";
 import { currentEnvironmentConfig, SQSHandlerFunction } from "../index.js";
 import { getEntraIdToken } from "../../../api/functions/entraId.js";
-import { genericConfig } from "../../../common/config.js";
+import { genericConfig, SecretConfig } from "../../../common/config.js";
 
-import { setPaidMembership } from "api/functions/membership.js";
+import {
+  MEMBER_CACHE_SECONDS,
+  setPaidMembership,
+} from "api/functions/membership.js";
 import { createAuditLogEntry } from "api/functions/auditLog.js";
 import { Modules } from "common/modules.js";
-import { getAuthorizedClients } from "../utils.js";
+import { getAuthorizedClients, getSecretConfig } from "../utils.js";
 import { emailMembershipPassHandler } from "./emailMembershipPassHandler.js";
+import RedisModule from "ioredis";
+import { setKey } from "api/functions/redisCache.js";
 
 export const provisionNewMemberHandler: SQSHandlerFunction<
   AvailableSQSFunctions.ProvisionNewMember
@@ -21,9 +26,16 @@ export const provisionNewMemberHandler: SQSHandlerFunction<
     secretName: genericConfig.EntraSecretName,
     logger,
   });
+  const secretConfig: SecretConfig = await getSecretConfig({
+    logger,
+    commonConfig,
+  });
+  const redisClient = new RedisModule.default(secretConfig.redis_url);
+  const netId = email.replace("@illinois.edu", "");
+  const cacheKey = `membership:${netId}:acmpaid`;
   logger.info("Got authorized clients and Entra ID token.");
   const { updated } = await setPaidMembership({
-    netId: email.replace("@illinois.edu", ""),
+    netId,
     dynamoClient: clients.dynamoClient,
     entraToken,
     paidMemberGroup: currentEnvironmentConfig.PaidMemberGroupId,
@@ -45,4 +57,12 @@ export const provisionNewMemberHandler: SQSHandlerFunction<
   } else {
     logger.info(`${email} was already a paid member.`);
   }
+  logger.info("Setting membership in Redis.");
+  await setKey({
+    redisClient,
+    key: cacheKey,
+    data: JSON.stringify({ isMember: true }),
+    expiresIn: MEMBER_CACHE_SECONDS,
+    logger,
+  });
 };


### PR DESCRIPTION
- Store membership cache in Redis.
- Cache all internal membership statuses for 12 hours.
- Cache all external membership statuses for 1 minute.
- Refresh cache on provisioning (in SQS handler).