### PR TITLE
Loosen NetID validation rules

### DIFF
--- a/src/common/types/generic.ts
+++ b/src/common/types/generic.ts
@@ -15,8 +15,8 @@ export const illinoisNetId = z
   .string()
   .min(3, { message: "NetID must be at least 3 characters." })
   .max(8, { message: "NetID cannot be more than 8 characters." })
-  .regex(/^[a-zA-Z]{2}[a-zA-Z-]*(?:[2-9]|[1-9][0-9]{1,2})?$/, {
-    message: "NetID is not valid!",
+  .regex(/^[a-z]{2}[a-z0-9-]{1,6}$/i, {
+    message: "NetID is malformed.",
   })
   .meta({
     description: "Valid Illinois NetID. See https://answers.uillinois.edu/illinois/page.php?id=78766 for more information.",


### PR DESCRIPTION
UIUC can't follow their own NetID issuance rules, so lets just check for the first 4 rules in the NetID rules instead of all of them.