### PR TITLE
Use acm.gg domain name for link shortener UI

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -158,7 +158,7 @@ const environmentConfig: EnvironmentConfigType = {
       /http:\/\/localhost:\d+$/,
     ],
     AadValidClientId: "5e08cf0f-53bb-4e09-9df2-e9bdc3467296",
-    LinkryBaseUrl: "https://go.acm.illinois.edu/",
+    LinkryBaseUrl: "https://acm.gg/",
     PasskitIdentifier: "pass.edu.illinois.acm.membership",
     PasskitSerialNumber: "0",
     EmailDomain: "acm.illinois.edu",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production environment service endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->