### PR TITLE
Setup linkry HTTPS certificate for acm.gg

### DIFF
--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -124,7 +124,8 @@ module "frontend" {
   CoreCertificateArn    = var.CoreCertificateArn
   CorePublicDomain      = var.CorePublicDomain
   IcalPublicDomain      = var.IcalPublicDomain
-  LinkryPublicDomain    = var.LinkryPublicDomain
+  LinkryPublicDomains   = [var.LinkryPublicDomain, "acm.gg"]
+  LinkryCertificateArn  = var.LinkryCertificateArn
   LinkryEdgeFunctionArn = module.lambdas.linkry_redirect_function_arn
 }
 

--- a/terraform/envs/prod/variables.tf
+++ b/terraform/envs/prod/variables.tf
@@ -24,6 +24,12 @@ variable "CoreCertificateArn" {
   default = "arn:aws:acm:us-east-1:298118738376:certificate/aeb93d9e-b0b7-4272-9c12-24ca5058c77e"
 }
 
+// For acm.gg we need a seperate cert for Linkry
+variable "LinkryCertificateArn" {
+  type    = string
+  default = "arn:aws:acm:us-east-1:298118738376:certificate/aa58a5e8-49eb-44fb-b118-ab0a7ecd2054"
+}
+
 variable "EmailDomain" {
   type    = string
   default = "acm.illinois.edu"

--- a/terraform/envs/qa/main.tf
+++ b/terraform/envs/qa/main.tf
@@ -127,8 +127,9 @@ module "frontend" {
   CoreCertificateArn    = var.CoreCertificateArn
   CorePublicDomain      = var.CorePublicDomain
   IcalPublicDomain      = var.IcalPublicDomain
-  LinkryPublicDomain    = var.LinkryPublicDomain
+  LinkryPublicDomains   = [var.LinkryPublicDomain]
   LinkryEdgeFunctionArn = module.lambdas.linkry_redirect_function_arn
+  LinkryCertificateArn  = var.LinkryCertificateArn
 }
 
 module "assets" {

--- a/terraform/envs/qa/variables.tf
+++ b/terraform/envs/qa/variables.tf
@@ -13,6 +13,12 @@ variable "CoreCertificateArn" {
   default = "arn:aws:acm:us-east-1:427040638965:certificate/63ccdf0b-d2b5-44f0-b589-eceffb935c23"
 }
 
+
+variable "LinkryCertificateArn" {
+  type    = string
+  default = "arn:aws:acm:us-east-1:427040638965:certificate/63ccdf0b-d2b5-44f0-b589-eceffb935c23"
+}
+
 variable "CorePublicDomain" {
   type    = string
   default = "core.aws.qa.acmuiuc.org"

--- a/terraform/modules/frontend/main.tf
+++ b/terraform/modules/frontend/main.tf
@@ -458,7 +458,7 @@ resource "aws_cloudfront_distribution" "linkry_cloudfront_distribution" {
       origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
     }
   }
-  aliases         = [var.LinkryPublicDomain]
+  aliases         = var.LinkryPublicDomains
   enabled         = true
   is_ipv6_enabled = true
   default_cache_behavior {
@@ -475,7 +475,7 @@ resource "aws_cloudfront_distribution" "linkry_cloudfront_distribution" {
     }
   }
   viewer_certificate {
-    acm_certificate_arn      = var.CoreCertificateArn
+    acm_certificate_arn      = var.LinkryCertificateArn
     minimum_protocol_version = "TLSv1.2_2021"
     ssl_support_method       = "sni-only"
   }

--- a/terraform/modules/frontend/variables.tf
+++ b/terraform/modules/frontend/variables.tf
@@ -28,9 +28,9 @@ variable "IcalPublicDomain" {
   description = "Ical Public Host"
 }
 
-variable "LinkryPublicDomain" {
-  type        = string
-  description = "Ical Public Host"
+variable "LinkryPublicDomains" {
+  type        = set(string)
+  description = "Linky Public Hosts"
 }
 
 
@@ -39,6 +39,10 @@ variable "CoreCertificateArn" {
   description = "Core ACM ARN"
 }
 
+variable "LinkryCertificateArn" {
+  type        = string
+  description = "Linkry ACM ARN"
+}
 
 variable "BucketPrefix" {
   type = string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Frontend now supports multiple public domains.
  * Added configurable certificate ARN parameter for deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->