### PR TITLE
Implement handling for new iCard swiper

### DIFF
--- a/src/ui/pages/tickets/ScanTickets.page.tsx
+++ b/src/ui/pages/tickets/ScanTickets.page.tsx
@@ -564,6 +564,18 @@ const ScanTicketsPageInternal: React.FC<ScanTicketsPageProps> = ({
 
       let email = inputValue;
 
+      // Check if input is from ACM card swiper (format: ACMCARD followed by 4 digits, followed by 9 digits)
+      if (email.startsWith("ACMCARD")) {
+        const uinMatch = email.match(/^ACMCARD(\d{4})(\d{9})/);
+        if (!uinMatch) {
+          setError("Invalid card swipe. Please try again.");
+          setIsLoading(false);
+          setShowModal(true);
+          return;
+        }
+        email = uinMatch[2]; // Extract the 9-digit UIN
+      }
+
       // Check if input is UIN (all digits)
       if (/^\d+$/.test(email)) {
         try {


### PR DESCRIPTION
Handles our new iCard swiper, which outputs format "ACMCARD(4 digits)(UIN)(otherstuff)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ACM card scanning support to the ticket entry flow. Users can now scan their physical ACM card to automatically retrieve their event tickets, replacing the need for manual identity entry. Invalid scans provide helpful error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->