### PR TITLE
Redesign ticketing check-in process

### DIFF
--- a/src/api/functions/tickets.ts
+++ b/src/api/functions/tickets.ts
@@ -9,6 +9,7 @@ export type GetUserPurchasesInputs = {
   dynamoClient: DynamoDBClient;
   email: string;
   logger: ValidLoggers;
+  productId?: string;
 };
 
 export type RawTicketEntry = {
@@ -36,6 +37,7 @@ export async function getUserTicketingPurchases({
   dynamoClient,
   email,
   logger,
+  productId,
 }: GetUserPurchasesInputs) {
   const issuedTickets: TicketInfoEntry[] = [];
   const ticketCommand = new QueryCommand({
@@ -44,7 +46,9 @@ export async function getUserTicketingPurchases({
     KeyConditionExpression: "ticketholder_netid = :email",
     ExpressionAttributeValues: {
       ":email": { S: email },
+      ...(productId && { ":productId": { S: productId } }),
     },
+    ...(productId && { FilterExpression: "event_id = :productId" }),
   });
   let ticketResults;
   try {
@@ -85,6 +89,7 @@ export async function getUserMerchPurchases({
   dynamoClient,
   email,
   logger,
+  productId,
 }: GetUserPurchasesInputs) {
   const issuedTickets: TicketInfoEntry[] = [];
   const merchCommand = new QueryCommand({
@@ -93,7 +98,9 @@ export async function getUserMerchPurchases({
     KeyConditionExpression: "email = :email",
     ExpressionAttributeValues: {
       ":email": { S: email },
+      ...(productId && { ":productId": { S: productId } }),
     },
+    ...(productId && { FilterExpression: "item_id = :productId" }),
   });
   let ticketsResult;
   try {
@@ -122,6 +129,7 @@ export async function getUserMerchPurchases({
         email: item.email,
         productId: item.item_id,
         quantity: item.quantity,
+        size: item.size,
       },
       refunded: item.refunded,
       fulfilled: item.fulfilled,

--- a/src/common/types/generic.ts
+++ b/src/common/types/generic.ts
@@ -25,6 +25,19 @@ export const illinoisNetId = z
     id: "IllinoisNetId",
   });
 
+export const illinoisUin = z
+  .string()
+  .length(9, { message: "UIN must be 9 characters." })
+  .regex(/^\d{9}$/i, {
+    message: "UIN is malformed.",
+  })
+  .meta({
+    description: "Valid Illinois UIN.",
+    example: "627838939",
+    id: "IllinoisUin",
+  });
+
+
 export const OrgUniqueId = z.enum(Object.keys(Organizations)).meta({
   description: "The unique org ID for a given ACM sub-organization. See https://github.com/acm-uiuc/js-shared/blob/main/src/orgs.ts#L15",
   examples: ["A01", "C01"],

--- a/src/common/types/user.ts
+++ b/src/common/types/user.ts
@@ -1,7 +1,8 @@
 import * as z from "zod/v4";
+import { illinoisUin } from "./generic.js";
 
 export const searchUserByUinRequest = z.object({
-  uin: z.string().length(9)
+  uin: illinoisUin
 });
 
 export const searchUserByUinResponse = z.object({

--- a/terraform/modules/frontend/main.tf
+++ b/terraform/modules/frontend/main.tf
@@ -248,6 +248,20 @@ resource "aws_cloudfront_distribution" "app_cloudfront_distribution" {
     }
   }
   ordered_cache_behavior {
+    path_pattern             = "/api/v1/tickets/getPurchasesByUser"
+    target_origin_id         = "HiCpuLambdaFunction-${var.CurrentActiveRegion}"
+    viewer_protocol_policy   = "redirect-to-https"
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"]
+    cache_policy_id          = aws_cloudfront_cache_policy.no_cache.id
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+    compress                 = true
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.origin_key_injection.arn
+    }
+  }
+  ordered_cache_behavior {
     path_pattern             = "/api/v1/events*"
     target_origin_id         = "LambdaFunction-${var.CurrentActiveRegion}"
     viewer_protocol_policy   = "redirect-to-https"

--- a/tests/unit/functions/tickets.test.ts
+++ b/tests/unit/functions/tickets.test.ts
@@ -228,6 +228,7 @@ describe("getUserMerchPurchases tests", () => {
         email: testEmail,
         productId: "merch-001",
         quantity: 2,
+        size: "L"
       },
       refunded: false,
       fulfilled: true,
@@ -240,6 +241,7 @@ describe("getUserMerchPurchases tests", () => {
         email: testEmail,
         productId: "merch-002",
         quantity: 1,
+        size: "M"
       },
       refunded: true,
       fulfilled: false,
@@ -348,6 +350,7 @@ describe("getUserMerchPurchases tests", () => {
         email: testEmail,
         productId: "merch-003",
         quantity: 1,
+        size: "S",
       },
       refunded: false,
       fulfilled: false,


### PR DESCRIPTION
- Require UIN or iCard swipe
- Do not call UIN endpoint on client side, instead call it on the server side to enforce no NetID can be used.
- Filter tickets for current event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Purchase lookup now supports UIN-based search as an alternative to email
  * Added product ID filtering for ticket and merchandise purchases
  * Merchandise items now include size information
  * Multi-select flow introduced for claiming multiple tickets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->