### PR TITLE
Run E2E tests only on prod deployments

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,7 +8,7 @@ on:
       - 'v*'
 
 jobs:
-  test:
+  test-unit:
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -70,7 +70,7 @@ jobs:
         id: get_version
         run: echo "VITE_BUILD_HASH=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_ENV"
 
-      - name: Run build
+      - name: Run Prod build
         run: make build
         env:
           HUSKY: "0"
@@ -88,6 +88,87 @@ jobs:
             dist/
             dist_ui/
 
+      - name: Clean and run QA build
+        run: rm -rf dist/ && rm -rf dist_ui/ && make build
+        env:
+          HUSKY: "0"
+          VITE_RUN_ENVIRONMENT: qa
+          RunEnvironment: qa
+
+      - name: Upload Build files
+        uses: actions/upload-artifact@v4
+        with:
+          include-hidden-files: true
+          name: build-qa
+          path: |
+            .aws-sam/
+            dist/
+            dist_ui/
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Run E2E testing
+    concurrency:
+      group: ${{ github.event.repository.name }}-dev-env
+      cancel-in-progress: false
+    permissions:
+      id-token: write
+      contents: read
+    needs:
+      - build
+    environment: "AWS QA"
+    steps:
+      - uses: actions/checkout@v5
+        env:
+          HUSKY: "0"
+
+      - name: Set up Node for testing
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.x
+          cache: "yarn"
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.12.2
+
+      - name: Restore Yarn Cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: yarn-modules-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-dev
+          restore-keys: |
+            yarn-modules-${{ runner.arch }}-${{ runner.os }}-
+
+      - name: Download Build files
+        uses: actions/download-artifact@v5
+        with:
+          name: build-qa
+
+      - uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: arn:aws:iam::427040638965:role/GitHubActionsRole
+          role-session-name: Core_QA_Deployment_${{ github.run_id }}
+          aws-region: us-east-2
+
+      - name: Publish to AWS
+        run: make deploy_qa
+        env:
+          HUSKY: "0"
+          VITE_RUN_ENVIRONMENT: dev
+
+      - name: Run health check
+        run: make dev_health_check
+
+      - name: Run E2E testing
+        run: make test_e2e
+        env:
+          JWT_KEY: ${{ secrets.JWT_KEY }}
+          PLAYWRIGHT_USERNAME: ${{ secrets.PLAYWRIGHT_USERNAME }}
+          PLAYWRIGHT_PASSWORD: ${{ secrets.PLAYWRIGHT_PASSWORD }}
+
   deploy-prod:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -99,8 +180,8 @@ jobs:
       id-token: write
       contents: read
     needs:
-      - test
-      - build
+      - test-unit
+      - test-e2e
     environment: "AWS PROD"
     steps:
       - name: Set up Node for testing

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -127,7 +127,6 @@ jobs:
         with:
           name: build
 
-
       - uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: arn:aws:iam::427040638965:role/GitHubActionsRole
@@ -143,9 +142,7 @@ jobs:
       - name: Run health check
         run: make dev_health_check
 
-      - name: Run post-deploy testing (Live and E2E)
-        run: make test_post_deploy -j 2
+      - name: Run live integration testing
+        run: make test_live_integration
         env:
-          PLAYWRIGHT_USERNAME: ${{ secrets.PLAYWRIGHT_USERNAME }}
-          PLAYWRIGHT_PASSWORD: ${{ secrets.PLAYWRIGHT_PASSWORD }}
           JWT_KEY: ${{ secrets.JWT_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,6 @@ test_e2e: install
 	yarn playwright install
 	yarn test:e2e
 
-test_post_deploy: test_live_integration test_e2e
-
 dev_health_check:
 	curl -f https://core.aws.qa.acmuiuc.org/api/v1/healthz && curl -f https://core.aws.qa.acmuiuc.org/
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured CI/CD deployment workflows with enhanced testing phases (unit tests and end-to-end tests now separated).
  * Improved QA build process and artifact management.
  * Refined post-deployment testing with live integration testing.
  * Streamlined deployment dependencies and workflow orchestration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->