### PR TITLE
Fix AWS region for Email handler

### DIFF
--- a/src/api/sqs/handlers/emailMembershipPassHandler.ts
+++ b/src/api/sqs/handlers/emailMembershipPassHandler.ts
@@ -16,7 +16,9 @@ export const emailMembershipPassHandler: SQSHandlerFunction<
 > = async (payload, metadata, logger) => {
   const { email, firstName } = payload;
   const commonConfig = { region: genericConfig.SesRegion };
-  const clients = await getAuthorizedClients(logger, commonConfig);
+  const clients = await getAuthorizedClients(logger, {
+    region: genericConfig.AwsRegion,
+  });
   const entraIdToken = await getEntraIdToken({
     clients: { ...clients },
     clientId: currentEnvironmentConfig.AadValidClientId,


### PR DESCRIPTION
Accidentally used SesRegion for getting Entra token instead of AwsRegion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration handling for cloud service integration.
  * Improved logging for authentication token processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->