### PR TITLE
Fix e2e tests spec for org info

### DIFF
--- a/tests/e2e/orgInfo.spec.ts
+++ b/tests/e2e/orgInfo.spec.ts
@@ -53,7 +53,7 @@ describe("Organization Info Tests", () => {
       `https://core.aws.qa.acmuiuc.org/api/v1/organizations?date=${date}`,
     );
     const json = (await data.json()) as RecursiveRecord[];
-    const infraEntry = json.find((x) => x.id === "Infrastructure Committee");
+    const infraEntry = json.find((x) => x.id === "C01");
 
     expect(infraEntry).toBeDefined();
     expect(infraEntry?.description).toBe(`Populated by E2E tests on ${date}`);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end organization test to use organization identifiers instead of names for API response validation, improving test precision.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->