### PR TITLE
Fix host rendering in iCal events

### DIFF
--- a/src/api/routes/ics.ts
+++ b/src/api/routes/ics.ts
@@ -13,7 +13,12 @@ import ical, {
   ICalEventRepeatingFreq,
 } from "ical-generator";
 import { getVtimezoneComponent } from "@touch4it/ical-timezones";
-import { AllOrganizationNameList, getOrgIdByName } from "@acm-uiuc/js-shared";
+import {
+  AllOrganizationNameList,
+  getOrgIdByName,
+  OrganizationId,
+  Organizations,
+} from "@acm-uiuc/js-shared";
 import { CLIENT_HTTP_CACHE_POLICY, EventRepeatOptions } from "./events.js";
 import rateLimiter from "api/plugins/rateLimiter.js";
 import { getCacheCounter } from "api/functions/cache.js";
@@ -44,6 +49,10 @@ function generateHostName(host: string) {
   }
   return `ACM@UIUC ${host}`;
 }
+
+const normalizeEventHost = (host: string): string => {
+  return Organizations[host as OrganizationId]?.name || host;
+};
 
 const icalPlugin: FastifyPluginAsync = async (fastify, _options) => {
   fastify.register(rateLimiter, {
@@ -147,8 +156,8 @@ const icalPlugin: FastifyPluginAsync = async (fastify, _options) => {
           end: endDate,
           summary: rawEvent.title,
           description: rawEvent.locationLink
-            ? `Host: ${rawEvent.host}\nGoogle Maps Link: ${rawEvent.locationLink}\n\n${rawEvent.description}`
-            : `Host: ${rawEvent.host}\n\n${rawEvent.description}`,
+            ? `Host: ${normalizeEventHost(rawEvent.host)}\nGoogle Maps Link: ${rawEvent.locationLink}\n\n${rawEvent.description}`
+            : `Host: ${normalizeEventHost(rawEvent.host)}\n\n${rawEvent.description}`,
           timezone: DEFAULT_TIMEZONE,
           organizer: generateHostName(host || "ACM"),
           id: rawEvent.id,

--- a/tests/unit/mockEventData.testdata.ts
+++ b/tests/unit/mockEventData.testdata.ts
@@ -18,7 +18,7 @@ const dynamoTableData = [
       BOOL: true,
     },
     host: {
-      S: "ACM",
+      S: "A01",
     },
     location: {
       S: "Main Quad",
@@ -143,7 +143,7 @@ const dynamoTableData = [
       BOOL: true,
     },
     host: {
-      S: "ACM",
+      S: "A01",
     },
     location: {
       S: "Legends",
@@ -204,7 +204,7 @@ const dynamoEventWithRepeatExclusion = {
     BOOL: false,
   },
   host: {
-    S: "ACM",
+    S: "A01",
   },
   location: {
     S: "ACM Room (Siebel CS 1104)",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Calendar event descriptions now display friendly organization names for event hosts, with automatic fallback to original identifiers when mappings are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->