### PR TITLE
Fix Store schema for openAt

### DIFF
--- a/src/common/types/store.ts
+++ b/src/common/types/store.ts
@@ -48,7 +48,7 @@ export const productSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional(),
   imageUrl: z.url().optional(),
-  openAt: z.number().int().positive().optional(), // Unix timestamp when sales open
+  openAt: z.number().int().gte(0).optional(), // Unix timestamp when sales open
   closeAt: z.number().int().min(0).optional(), // Unix timestamp when sales close
   stripeProductId: z.string().optional(), // Stripe product ID
   limitConfiguration: limitConfigurationSchema.optional(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed product opening time validation to accept zero and positive integer values. Previously, only strictly positive timestamps were permitted. This change enables more flexible time-based configurations and eliminates validation errors during product creation and management workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->