### PR TITLE
Add PATCH route to modify store products

### DIFF
--- a/src/common/types/store.ts
+++ b/src/common/types/store.ts
@@ -1,3 +1,4 @@
+import { X25519KeyPairOptions } from "node:crypto";
 import * as z from "zod/v4";
 
 // ============ Constants ============
@@ -69,6 +70,20 @@ export const productSchema = z.object({
 });
 
 export type Product = z.infer<typeof productSchema>;
+
+export const modifyProductSchema = productSchema.pick({
+  name: true,
+  description: true,
+  imageUrl: true,
+  openAt: true,
+  closeAt: true,
+  limitConfiguration: true,
+  verifiedIdentityRequired: true,
+}).partial().extend({
+  verifiedIdentityRequired: z.boolean().optional(), // Override to remove the default
+});
+
+export type ModifyProduct = z.infer<typeof modifyProductSchema>;
 
 // ============ Product with Variants (for API responses) ============
 export const productWithVariantsSchema = productSchema.extend({

--- a/tests/live/store.test.ts
+++ b/tests/live/store.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+import { getBaseEndpoint } from "./utils.js";
+
+const baseEndpoint = getBaseEndpoint();
+
+describe("Get store products", async () => {
+  test("Get all store products", async () => {
+    const response = await fetch(`${baseEndpoint}/api/v1/store/products`);
+    expect(response.status).toBe(200);
+    const getResponseJson = await response.json();
+    expect(getResponseJson).toHaveProperty("products");
+    expect(getResponseJson["products"].length).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to modify product metadata via admin endpoint. Store managers can now update product details including name, description, image, availability times, quantity limits, and identity verification requirements in a single atomic operation.

* **Tests**
  * Added comprehensive test coverage for the new product modification functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->