### PR TITLE
Fix output schema for admin store product endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infra-core",
-  "version": "4.9.4",
+  "version": "4.9.5",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/src/api/routes/store.ts
+++ b/src/api/routes/store.ts
@@ -30,6 +30,7 @@ import {
   createProductRequestSchema,
   listProductsPublicResponseSchema,
   productWithVariantsPublicCountSchema,
+  productWithVariantsSchema,
   modifyProductSchema,
   listProductsAdminResponseSchema,
   ModifyProductRequest,
@@ -236,7 +237,7 @@ const storeRoutes: FastifyPluginAsync = async (fastify, _options) => {
               description: "Product details.",
               content: {
                 "application/json": {
-                  schema: productWithVariantsPublicCountSchema,
+                  schema: productWithVariantsSchema,
                 },
               },
             },


### PR DESCRIPTION
The admin endpoint for getting a specific product was not outputting the sold count, causing NaNs on the UI.